### PR TITLE
Add babel-cli as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
+    "babel-cli": "^6.26.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-exponentiation-operator": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",


### PR DESCRIPTION
[babel-cli](https://www.npmjs.com/package/babel-cli) is now added as dependency, so it's no more needed to add it to apps.