### PR TITLE
v1.1.0 release

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -11,11 +11,11 @@ describe('Medopad\'s Babel preset', () => {
     should(preset).have.property('plugins')
   })
 
-  it('should have 1 preset listed', () => {
+  it('should have all required presets listed', () => {
     should(preset.presets.length).equal(1)
   })
 
-  it('should have 4 plugins listed', () => {
+  it('should have all required plugins listed', () => {
     should(preset.plugins.length).equal(4)
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-medopad",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Medopad's Babel preset.",
   "keywords": [
     "babel",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [
     "babel",
     "babelpreset",
-    "medopad"
+    "medopad",
+    "ecmascript"
   ],
   "license": "MIT",
   "author": "Julius Osokinas <julius.osokinas@medopad.com>",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "babel-cli": "^6.26.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+    "babel-plugin-transform-class-properties": "^6.24.0",
+    "babel-plugin-transform-exponentiation-operator": "^6.24.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0"
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint-config-medopad": "^3.4.0",
     "mocha": "^3.5.0",
-    "should": "^11.2.1"
+    "should": "^11.2.0"
   },
   "scripts": {
     "test": "eslint . && mocha *.test.js",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-class-properties": "^6.24.0",
     "babel-plugin-transform-exponentiation-operator": "^6.24.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0"
   },
   "devDependencies": {
-    "eslint-config-medopad": "^3.4.0",
+    "eslint-config-medopad": "^3.6.0",
     "mocha": "^3.5.0",
     "should": "^11.2.0"
   },


### PR DESCRIPTION
v1.1.0 release notes:

- Added [babel-cli](https://www.npmjs.com/package/babel-cli) as dependency
- Added README info about plugins used
- Added README info about using preset with [ESLint](https://github.com/eslint/eslint)
- Added README info about using preset with [webpack](https://github.com/webpack/webpack)
- Minor updates of dependencies
