### PR TITLE
Do not specify Linux distribution for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 sudo: required
 
 env:


### PR DESCRIPTION
Travis CI [will no longer need](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) Trusty set as Linux distribution for running tests, as it is the default one now.