### PR TITLE
Do not require "sudo" for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 env:
   - CXX="g++-4.8"
 


### PR DESCRIPTION
Travis CI [will no longer need](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) "sudo" set as a requirement for running tests, as it sets this by default now.